### PR TITLE
Update reponse\request actions, fix PostAsync

### DIFF
--- a/LiqPaySDK/LiqPay.SDK/Dto/Enums/LiqPayRequestAction.cs
+++ b/LiqPaySDK/LiqPay.SDK/Dto/Enums/LiqPayRequestAction.cs
@@ -27,6 +27,8 @@ namespace LiqPay.SDK.Dto.Enums
         [EnumMember(Value = "paydonate")]
         Paydonate,
         [EnumMember(Value = "auth")]
-        Auth
+        Auth,
+        [EnumMember(Value = "status")]
+        Status,
     }
 }

--- a/LiqPaySDK/LiqPay.SDK/Dto/Enums/LiqPayResponseAction.cs
+++ b/LiqPaySDK/LiqPay.SDK/Dto/Enums/LiqPayResponseAction.cs
@@ -17,6 +17,8 @@ namespace LiqPay.SDK.Dto.Enums
         [EnumMember(Value = "auth")]
         Auth,
         [EnumMember(Value = "regular")]
-        Regular
+        Regular,
+        [EnumMember(Value = "paycash")]
+        Paycash
     }
 }

--- a/LiqPaySDK/LiqPay.SDK/Dto/Enums/LiqPayResponseStatus.cs
+++ b/LiqPaySDK/LiqPay.SDK/Dto/Enums/LiqPayResponseStatus.cs
@@ -19,6 +19,10 @@ namespace LiqPay.SDK.Dto.Enums
         [EnumMember(Value = "invoice_wait")]
         InvoiceWait,
         [EnumMember(Value = "try_again")]
-        TryAgain
+        TryAgain,
+        [EnumMember(Value = "reversed")]
+        Reversed,
+        [EnumMember(Value = "cash_wait")]
+        CashWait,
     }
 }

--- a/LiqPaySDK/LiqPay.SDK/Dto/LiqPayResponse.cs
+++ b/LiqPaySDK/LiqPay.SDK/Dto/LiqPayResponse.cs
@@ -1,4 +1,5 @@
-﻿using LiqPay.SDK.Dto.Enums;
+﻿using System;
+using LiqPay.SDK.Dto.Enums;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System.Collections.Generic;
@@ -45,5 +46,14 @@ namespace LiqPay.SDK.Dto
         public string ErrorDescription { get; set; }
         [JsonProperty("invoice_id")]
         public int? InvoiceId { get; set; }
+        [JsonProperty("refund_amount")]
+        public double RefundAmount { get; set; }
+        [JsonProperty("refund_date_last")]
+        [JsonConverter(typeof(LiqMillisecondEpochConverter))]
+        public DateTime? RefundDateLast { get; set; }
+        [JsonProperty("create_date")]
+        [JsonConverter(typeof(LiqMillisecondEpochConverter))]
+        public DateTime CreateDate { get; set; }
+        
     }
 }

--- a/LiqPaySDK/LiqPay.SDK/LiqMillisecondEpochConverter.cs
+++ b/LiqPaySDK/LiqPay.SDK/LiqMillisecondEpochConverter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace LiqPay.SDK
+{
+    public class LiqMillisecondEpochConverter : DateTimeConverterBase
+    {
+        private static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            writer.WriteRawValue(((DateTime)value - Epoch).TotalMilliseconds.ToString());
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.Value == null) { return null; }
+            return Epoch.AddMilliseconds((long)reader.Value);
+        }
+    }
+}

--- a/LiqPaySDK/LiqPay.SDK/LiqPayClientHelper.cs
+++ b/LiqPaySDK/LiqPay.SDK/LiqPayClientHelper.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -12,17 +13,16 @@ namespace LiqPay.SDK
         public static async Task<string> PostAsync(string url, Dictionary<string, string> data, WebProxy proxy = null)
         {
             string urlParameters = null;
-
+            var parameters = new List<string>();
             foreach (var item in data)
             {
                 var queryValue = WebUtility.HtmlEncode(item.Value);
                 byte[] bytes = Encoding.Default.GetBytes(queryValue);
                 var utf8QueryValue = Encoding.UTF8.GetString(bytes);
-
-
-                urlParameters = $"{item.Key}={utf8QueryValue}&";
+                
+                parameters.Add($"{item.Key}={utf8QueryValue}");
             }
-
+            urlParameters = string.Join("&", parameters);
             var httpClientHandler = new HttpClientHandler()
             {
                 Proxy = proxy


### PR DESCRIPTION
Add missing ResponseAction and ResponseStatus (looks like LiqPay docs a bit outdated).
Add MillisecondEpochConverter to convert LiqPay's unix timestamps.
Add fix for PostAsync method.