### PR TITLE
Added ConfigureAwait(false)

### DIFF
--- a/LiqPaySDK/LiqPay.SDK/LiqPayClient.cs
+++ b/LiqPaySDK/LiqPay.SDK/LiqPayClient.cs
@@ -54,7 +54,10 @@ namespace LiqPay.SDK
         public async Task<LiqPayResponse> RequestAsync(string path, LiqPayRequest requestParams)
         {
             var data = PrepareRequestData(requestParams);
-			string response = await LiqPayClientHelper.PostAsync($"{LiqPayConsts.LiqpayApiUrl}{path}", data, Proxy).ConfigureAwait(false);
+
+			string response = await LiqPayClientHelper
+                .PostAsync($"{LiqPayConsts.LiqpayApiUrl}{path}", data, Proxy)
+                .ConfigureAwait(false);
 
             return JsonConvert.DeserializeObject<LiqPayResponse>(response);
         }

--- a/LiqPaySDK/LiqPay.SDK/LiqPayClient.cs
+++ b/LiqPaySDK/LiqPay.SDK/LiqPayClient.cs
@@ -54,7 +54,7 @@ namespace LiqPay.SDK
         public async Task<LiqPayResponse> RequestAsync(string path, LiqPayRequest requestParams)
         {
             var data = PrepareRequestData(requestParams);
-            string response = await LiqPayClientHelper.PostAsync(LiqPayConsts.LiqpayApiUrl + path, data, Proxy);
+			string response = await LiqPayClientHelper.PostAsync($"{LiqPayConsts.LiqpayApiUrl}{path}", data, Proxy).ConfigureAwait(false);
 
             return JsonConvert.DeserializeObject<LiqPayResponse>(response);
         }

--- a/LiqPaySDK/LiqPay.SDK/LiqPayClientHelper.cs
+++ b/LiqPaySDK/LiqPay.SDK/LiqPayClientHelper.cs
@@ -30,7 +30,7 @@ namespace LiqPay.SDK
             {
                 var encoding = Encoding.GetEncoding(Encoding.UTF8.CodePage);
 
-				string urlParameters = string.Join("&", parameters);
+				var urlParameters = string.Join("&", parameters);
                 var stringContent = new StringContent(urlParameters);
 
 				using (var responseMessage = await httpClient.PostAsync(url, stringContent).ConfigureAwait(false))

--- a/LiqPaySDK/LiqPay.SDK/LiqPayClientHelper.cs
+++ b/LiqPaySDK/LiqPay.SDK/LiqPayClientHelper.cs
@@ -37,7 +37,7 @@ namespace LiqPay.SDK
                 {
                     responseMessage.EnsureSuccessStatusCode();
 
-                    using (var responseStream = await responseMessage.Content.ReadAsStreamAsync())
+                    using (var responseStream = await responseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false))
                     using (var reader = new StreamReader(responseStream, encoding))
                     {
 						return reader.ReadToEnd();

--- a/LiqPaySDK/LiqPay.SDK/LiqPayClientHelper.cs
+++ b/LiqPaySDK/LiqPay.SDK/LiqPayClientHelper.cs
@@ -29,9 +29,11 @@ namespace LiqPay.SDK
             using (var httpClient = new HttpClient(httpClientHandler))
             {
                 var encoding = Encoding.GetEncoding(Encoding.UTF8.CodePage);
-				string urlParameters = string.Join("&", parameters);
 
-				using (var responseMessage = await httpClient.PostAsync(url, new StringContent(urlParameters)).ConfigureAwait(false))
+				string urlParameters = string.Join("&", parameters);
+                var stringContent = new StringContent(urlParameters);
+
+				using (var responseMessage = await httpClient.PostAsync(url, stringContent).ConfigureAwait(false))
                 {
                     responseMessage.EnsureSuccessStatusCode();
 

--- a/LiqPaySDK/LiqPay.SDK/LiqPayClientHelper.cs
+++ b/LiqPaySDK/LiqPay.SDK/LiqPayClientHelper.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -8,11 +7,10 @@ using System.Threading.Tasks;
 
 namespace LiqPay.SDK
 {
-    public class LiqPayClientHelper
+	public class LiqPayClientHelper
     {
         public static async Task<string> PostAsync(string url, Dictionary<string, string> data, WebProxy proxy = null)
         {
-            string urlParameters = null;
             var parameters = new List<string>();
             foreach (var item in data)
             {
@@ -22,7 +20,7 @@ namespace LiqPay.SDK
                 
                 parameters.Add($"{item.Key}={utf8QueryValue}");
             }
-            urlParameters = string.Join("&", parameters);
+
             var httpClientHandler = new HttpClientHandler()
             {
                 Proxy = proxy
@@ -31,13 +29,17 @@ namespace LiqPay.SDK
             using (var httpClient = new HttpClient(httpClientHandler))
             {
                 var encoding = Encoding.GetEncoding(Encoding.UTF8.CodePage);
-                using (var responseMessage = await httpClient.PostAsync(url, new StringContent(urlParameters)))
+				string urlParameters = string.Join("&", parameters);
+
+				using (var responseMessage = await httpClient.PostAsync(url, new StringContent(urlParameters)).ConfigureAwait(false))
                 {
                     responseMessage.EnsureSuccessStatusCode();
 
                     using (var responseStream = await responseMessage.Content.ReadAsStreamAsync())
                     using (var reader = new StreamReader(responseStream, encoding))
-                        return reader.ReadToEnd();
+                    {
+						return reader.ReadToEnd();
+					}
                 }
             }
         }

--- a/LiqPaySDK/LiqPay.SDK/LiqPayClientHelper.cs
+++ b/LiqPaySDK/LiqPay.SDK/LiqPayClientHelper.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace LiqPay.SDK
 {
-	public class LiqPayClientHelper
+    public class LiqPayClientHelper
     {
         public static async Task<string> PostAsync(string url, Dictionary<string, string> data, WebProxy proxy = null)
         {


### PR DESCRIPTION
Added ConfigureAwait(false) since it's a general purpose library which can be used from many different apps with different SyncronizationContexts and you can't be sure as to how exactly a user would get a value from a task returned by RequestAsync method.

It may work well from the ASP.NET Core app because SyncronizationContext doesn't exist there, however if you try to use this library from let's say a WPF app and don't await it, but use .Result instead, as of right now, you'd get a deadlock, since the SynchronizationContext is basically a UI thread in this case. Thus it's a general recommendation to use ConfigureAwait(false) in libraries like this.